### PR TITLE
feat(dns): add SES DKIM, DMARC & MAIL FROM DNS records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,25 @@ amplify_outputs*
 amplifyconfiguration*
 aws-exports.js
 
+# terraform
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+!example.tfvars
+!*.example.tfvars
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+!override.example.tf
+.terraformrc
+terraform.rc
+*.plan
+
+# custom
+
 data

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "6.12.0"
+  hashes = [
+    "h1:QiSzB4pjONZ4hek1L8Rcd6S9vtP+yMr5iOfczJg5/JI=",
+    "zh:054bcbf13c6ac9ddd2247876f82f9b56493e2f71d8c88baeec142386a395165d",
+    "zh:195489f16ad5621db2cec80be997d33060462a3b8d442c890bef3eceba34fa4d",
+    "zh:3461ef14904ab7de246296e44d24c042f3190e6bead3d7ce1d9fda63dcb0f047",
+    "zh:44517a0035996431e4127f45db5a84f53ce80730eae35629eda3101709df1e5c",
+    "zh:4b0374abaa6b9a9debed563380cc944873e4f30771dd1da7b9e812a49bf485e3",
+    "zh:531468b99465bd98a89a4ce2f1a30168dfadf6edb57f7836df8a977a2c4f9804",
+    "zh:6a95ed7b4852174aa748d3412bff3d45e4d7420d12659f981c3d9f4a1a59a35f",
+    "zh:88c2d21af1e64eed4a13dbb85590c66a519f3ecc54b72875d4bb6326f3ef84e7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a8b648470bb5df098e56b1ec5c6a39e0bbb7b496b23a19ea9f494bf48d4a122a",
+    "zh:b23fb13efdb527677db546bc92aeb2bdf64ff3f480188841f2bfdfa7d3d907c1",
+    "zh:be5858a1951ae5f5a9c388949c3e3c66a3375f684fb79b06b1d1db7a9703b18e",
+    "zh:c368e03a7c922493daf4c7348faafc45f455225815ef218b5491c46cea5f76b7",
+    "zh:e31e75d5d19b8ac08aa01be7e78207966e1faa3b82ed9fe3acfdc2d806be924c",
+    "zh:ea84182343b5fd9252a6fae41e844eed4fdc3311473a753b09f06e49ec0e7853",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,30 @@
+# Terraform DNS Infrastructure
+
+This directory contains Terraform configuration that manages **only Route 53 DNS records** required for email authentication and custom MAIL FROM support for the `wellcomecollection.org` domain in the context of this AWS Amplify project.
+
+## Scope
+Managed via Terraform here:
+* Hosted zone lookup (data source) for `wellcomecollection.org`.
+* Three Amazon SES DKIM selector CNAME records.
+* A DMARC monitoring TXT record (`_dmarc.wellcomecollection.org`) with a `p=none` policy (no enforcement; enables future reporting if rua/ruf tags are added later).
+* Custom MAIL FROM domain records for SES in `eu-west-2`:
+	* MX record pointing at `feedback-smtp.eu-west-2.amazonses.com`.
+	* SPF (TXT) record: `v=spf1 include:amazonses.com ~all` (scoped to the MAIL FROM subdomain, separate from the apex SPF already present outside this config).
+
+## Out of Scope
+All application hosting, APIs, storage, and related infrastructure are provisioned by **AWS Amplify** (see project root / Amplify configuration). This Terraform module intentionally avoids overlapping with Amplify-managed resources.
+
+## Apply Workflow
+1. Ensure AWS credentials/assume role permitting Route 53 changes (role specified in `terraform.tf`).
+2. Run `terraform init` (first time or after provider changes).
+3. Run `terraform plan` to review proposed DNS record creations.
+4. Run `terraform apply` to create the records.
+
+## Verification (Post-Apply)
+Example dig checks (optional):
+```
+dig +short CNAME g6j34hsjpzr3g5gylbmsaab7nr4zoedq._domainkey.wellcomecollection.org
+dig +short TXT _dmarc.wellcomecollection.org
+dig +short MX  ses-eu-west-2.wellcomecollection.org
+dig +short TXT ses-eu-west-2.wellcomecollection.org
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,63 @@
+# Look up the hosted zone for wellcomecollection.org
+data "aws_route53_zone" "wellcomecollection_org" {
+  name     = "wellcomecollection.org."
+  provider = aws.dns
+}
+
+# DKIM CNAME records
+resource "aws_route53_record" "dkim_1" {
+  zone_id  = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name     = "g6j34hsjpzr3g5gylbmsaab7nr4zoedq._domainkey.wellcomecollection.org"
+  type     = "CNAME"
+  ttl      = 300
+  records  = ["g6j34hsjpzr3g5gylbmsaab7nr4zoedq.dkim.amazonses.com"]
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "dkim_2" {
+  zone_id  = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name     = "snr5tjslon4rcxtcd65fjrxmk4g2spnr._domainkey.wellcomecollection.org"
+  type     = "CNAME"
+  ttl      = 300
+  records  = ["snr5tjslon4rcxtcd65fjrxmk4g2spnr.dkim.amazonses.com"]
+  provider = aws.dns
+}
+
+resource "aws_route53_record" "dkim_3" {
+  zone_id  = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name     = "3pti23e56njonwgmiluz32tqtdylhkpv._domainkey.wellcomecollection.org"
+  type     = "CNAME"
+  ttl      = 300
+  records  = ["3pti23e56njonwgmiluz32tqtdylhkpv.dkim.amazonses.com"]
+  provider = aws.dns
+}
+
+# DMARC TXT record
+resource "aws_route53_record" "dmarc" {
+  zone_id  = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name     = "_dmarc.wellcomecollection.org"
+  type     = "TXT"
+  ttl      = 300
+  records  = ["v=DMARC1; p=none;"]
+  provider = aws.dns
+}
+
+# Custom MAIL FROM MX record
+resource "aws_route53_record" "mail_from_mx" {
+  zone_id  = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name     = "ses-eu-west-2.wellcomecollection.org"
+  type     = "MX"
+  ttl      = 300
+  records  = ["10 feedback-smtp.eu-west-2.amazonses.com"]
+  provider = aws.dns
+}
+
+# Custom MAIL FROM SPF TXT record
+resource "aws_route53_record" "mail_from_spf" {
+  zone_id  = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name     = "ses-eu-west-2.wellcomecollection.org"
+  type     = "TXT"
+  ttl      = 300
+  records  = ["v=spf1 include:amazonses.com ~all"]
+  provider = aws.dns
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  region = "eu-west-1"
+  alias  = "dns"
+
+  assume_role {
+    role_arn = "arn:aws:iam::267269328833:role/wellcomecollection-assume_role_hosted_zone_update"
+  }
+
+  default_tags {
+    tags = {
+      TerraformConfigurationURL = "https://github.com/wellcomecollection/wellcomecollection.org/tree/main/cache"
+      Department                = "Digital Platform"
+      Division                  = "Culture and Society"
+      Use                       = "Front-end CloudFront distributions"
+    }
+  }
+}
+
+terraform {
+  required_version = ">= 0.9"
+
+  backend "s3" {
+    assume_role = {
+      role_arn = "arn:aws:iam::760097843905:role/platform-developer"
+    }
+
+    bucket         = "wellcomecollection-platform-infra"
+    key            = "terraform/wc_name_rec_eval.tfstate"
+    dynamodb_table = "terraform-locktable"
+    region         = "eu-west-1"
+  }
+}


### PR DESCRIPTION
## What does this change?

Adds Terraform-managed Route 53 DNS records for email authentication (SES DKIM) and a custom MAIL FROM domain, plus a DMARC monitoring record. Introduces isolated Terraform configuration (DNS only) for the `wellcomecollection.org` zone. 

> [!Note]
> Terraform has ALREADY been applied; records exist in Route 53.

## How to test
1. Inspect DNS: 
   - `dig +short CNAME g6j34hsjpzr3g5gylbmsaab7nr4zoedq._domainkey.wellcomecollection.org`
   - `dig +short TXT _dmarc.wellcomecollection.org`
   - `dig +short MX ses-eu-west-2.wellcomecollection.org`
   - `dig +short TXT ses-eu-west-2.wellcomecollection.org`
2. (Optional) Run `terraform plan` locally on this branch; it should show no changes.

## How can we measure success?
* DKIM: SES console reports verified DKIM (eventually).
* DMARC: Receivers begin evaluating policy (monitor-only).
* Future ability to tighten DMARC without manual DNS edits.

## Have we considered potential risks?
* DMARC policy is `p=none` so no delivery enforcement yet.
* All record names were new; no overwrite of existing DNS.
* Locking provider version ensures stable future plans.

