### PR TITLE
Add subdomain records for narese.wellcomecollection.org

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,28 +3,59 @@
 This directory contains Terraform configuration that manages **only Route 53 DNS records** required for email authentication and custom MAIL FROM support for the `wellcomecollection.org` domain in the context of this AWS Amplify project.
 
 ## Scope
+
 Managed via Terraform here:
+
 * Hosted zone lookup (data source) for `wellcomecollection.org`.
 * Three Amazon SES DKIM selector CNAME records.
 * A DMARC monitoring TXT record (`_dmarc.wellcomecollection.org`) with a `p=none` policy (no enforcement; enables future reporting if rua/ruf tags are added later).
 * Custom MAIL FROM domain records for SES in `eu-west-2`:
-	* MX record pointing at `feedback-smtp.eu-west-2.amazonses.com`.
-	* SPF (TXT) record: `v=spf1 include:amazonses.com ~all` (scoped to the MAIL FROM subdomain, separate from the apex SPF already present outside this config).
+  * MX record pointing at `feedback-smtp.eu-west-2.amazonses.com`.
+  * SPF (TXT) record: `v=spf1 include:amazonses.com ~all` (scoped to the MAIL FROM subdomain, separate from the apex SPF already present outside this config).
+  * Application CNAME for `narese.wellcomecollection.org` -> `d3nrdbrjtfgvc3.cloudfront.net` (Amplify distribution).
+  * ACM/Amplify domain validation CNAME for `narese.wellcomecollection.org`.
 
 ## Out of Scope
+
 All application hosting, APIs, storage, and related infrastructure are provisioned by **AWS Amplify** (see project root / Amplify configuration). This Terraform module intentionally avoids overlapping with Amplify-managed resources.
 
 ## Apply Workflow
+
 1. Ensure AWS credentials/assume role permitting Route 53 changes (role specified in `terraform.tf`).
 2. Run `terraform init` (first time or after provider changes).
 3. Run `terraform plan` to review proposed DNS record creations.
 4. Run `terraform apply` to create the records.
 
 ## Verification (Post-Apply)
+
 Example dig checks (optional):
-```
+
+```bash
 dig +short CNAME g6j34hsjpzr3g5gylbmsaab7nr4zoedq._domainkey.wellcomecollection.org
 dig +short TXT _dmarc.wellcomecollection.org
 dig +short MX  ses-eu-west-2.wellcomecollection.org
 dig +short TXT ses-eu-west-2.wellcomecollection.org
+dig +short CNAME narese.wellcomecollection.org || dig +short A narese.wellcomecollection.org
 ```
+
+## narese records
+
+Two records are managed for the application subdomain:
+
+```hcl
+resource "aws_route53_record" "narese" { # Points the subdomain to Amplify/CloudFront
+  name    = "narese.wellcomecollection.org"
+  type    = "CNAME"
+  records = ["d3nrdbrjtfgvc3.cloudfront.net"]
+  ttl     = 300
+}
+
+resource "aws_route53_record" "narese_domain_validation" { # ACM validation token
+  name    = "_ba97b5f71e8caa1a4ddb90a021418ef0.narese.wellcomecollection.org"
+  type    = "CNAME"
+  records = ["_69037f5d999b22d83f4f04a6ac8466b3.xlfgrmvvlj.acm-validations.aws"]
+  ttl     = 300
+}
+```
+
+If Amplify rotates validation tokens in the future, update only the `narese_domain_validation` record.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -61,3 +61,26 @@ resource "aws_route53_record" "mail_from_spf" {
   records  = ["v=spf1 include:amazonses.com ~all"]
   provider = aws.dns
 }
+
+# Application hostname for narese.wellcomecollection.org
+# Points subdomain at Amplify/CloudFront distribution. If distribution/domain changes,
+# update the CNAME target below. For direct IP mapping, switch to an A record.
+# TTL kept at 300 for flexibility; increase once stable (e.g. 3600).
+resource "aws_route53_record" "narese" {
+  zone_id = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name    = "narese.wellcomecollection.org"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["d3nrdbrjtfgvc3.cloudfront.net"]
+  provider = aws.dns
+}
+
+# Amplify / ACM domain validation CNAME for narese.wellcomecollection.org
+resource "aws_route53_record" "narese_domain_validation" {
+  zone_id  = data.aws_route53_zone.wellcomecollection_org.zone_id
+  name     = "_ba97b5f71e8caa1a4ddb90a021418ef0.narese.wellcomecollection.org"
+  type     = "CNAME"
+  ttl      = 300
+  records  = ["_69037f5d999b22d83f4f04a6ac8466b3.xlfgrmvvlj.acm-validations.aws"]
+  provider = aws.dns
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -20,10 +20,10 @@ terraform {
   required_version = ">= 0.9"
 
   backend "s3" {
-    assume_role = {
-      role_arn = "arn:aws:iam::760097843905:role/platform-developer"
-    }
-
+  # Authentication for the backend must be supplied via environment variables or
+  # an AWS profile. The S3 backend does not support an inline assume_role block.
+  # If you have a local profile that assumes the required role, specify it here.
+  profile       = "platform-developer"
     bucket         = "wellcomecollection-platform-infra"
     key            = "terraform/wc_name_rec_eval.tfstate"
     dynamodb_table = "terraform-locktable"


### PR DESCRIPTION
## What does this change?

Adds Terraform-managed Route 53 DNS records required for:

* Application CNAME for `narese.wellcomecollection.org` pointing at the Amplify/CloudFront distribution (`d3nrdbrjtfgvc3.cloudfront.net`).
* ACM/Amplify domain validation CNAME for `narese.wellcomecollection.org` to support certificate issuance / domain association.

> [!Note]
> This terraform change has been applied.

## How to test

Pre-merge (dry run):
1. From the `terraform/` directory run:
   - `terraform init`
   - `terraform plan`
2. Confirm the plan shows creation of the expected records

Post-apply verification (once merged & applied in CI or manually):
```bash
dig +short CNAME narese.wellcomecollection.org
dig +short CNAME _ba97b5f71e8caa1a4ddb90a021418ef0.narese.wellcomecollection.org
```
All queries should return the values defined in `main.tf`

## How can we measure success?

* Application reachable at `https://narese.wellcomecollection.org/` via Amplify distribution (after Amplify domain association completes).
* No manual DNS drift — subsequent `terraform plan` shows zero changes.

## Have we considered potential risks?

No secrets are stored in state; only public DNS values.
